### PR TITLE
✅ fix(android): fall back to a copy when symlink creation lacks the Windows privilege

### DIFF
--- a/.changes/windows-symlink-copy-fallback.md
+++ b/.changes/windows-symlink-copy-fallback.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fall back to copying the jniLibs artifact when symlink creation is denied on Windows (no Developer Mode / SeCreateSymbolicLinkPrivilege), so `tauri android build` no longer aborts on Windows machines without symlink privileges

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -110,6 +110,7 @@ fn copy_dir_all_inner(
         log::warn!("skipping already-copied directory {:?}", source);
         return Ok(());
     }
+    std::fs::create_dir_all(target)?;
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
         let dest = target.join(entry.file_name());

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -91,7 +91,6 @@ pub fn force_symlink(
 }
 
 fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(target)?;
     // Cycle guard: `metadata()` follows symlinks, so a self-referential or
     // ancestor-pointing link would recurse forever and abort the whole
     // fallback with a path-length error — the exact failure this fallback was
@@ -107,7 +106,7 @@ fn copy_dir_all_inner(
 ) -> std::io::Result<()> {
     let canonical = source.canonicalize()?;
     if !visited.insert(canonical.clone()) {
-        log::warn!("skipping already-copied directory {:?}", source);
+        log::warn!("skipping {:?}: ancestor cycle in symlinked tree", source);
         return Ok(());
     }
     std::fs::create_dir_all(target)?;

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -126,12 +126,12 @@ fn copy_dir_all_entries(
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
         let dest = target.join(entry.file_name());
-        // metadata() follows symlinks: a symlinked subdirectory inside the
-        // source tree must recurse as a directory, not fail in the copy
-        // branch below. A broken link (dangling, or a self-referential loop)
+        // std::fs::metadata follows symlinks: a symlinked subdirectory
+        // inside the source tree must recurse as a directory. A broken link
+        // (dangling, or a self-referential loop) resolves with an error and
         // is skipped with a warning rather than failing the whole fallback —
         // the symlink being replaced here was best-effort to begin with.
-        let entry_type = match entry.metadata() {
+        let entry_type = match std::fs::metadata(entry.path()) {
             Ok(metadata) => metadata.file_type(),
             Err(err) => {
                 log::warn!("skipping {:?} while copying: {err}", entry.path());

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -56,12 +56,12 @@ pub fn force_symlink(
     } else if target.is_dir() {
         remove_dir_all(&target).map_err(|err| error(ErrorCause::IOError(err)))?;
     }
-    let result = if is_directory {
+    let _result = if is_directory {
         std::os::windows::fs::symlink_dir(source, &target)
     } else {
         std::os::windows::fs::symlink_file(source, &target)
     };
-    let result = match result {
+    let result = match _result {
         Err(err) if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD.0 as i32) => {
             // Creating symlinks on Windows requires Developer Mode or the
             // SeCreateSymbolicLinkPrivilege policy. Fall back to a copy: the
@@ -70,26 +70,22 @@ pub fn force_symlink(
             // over a missing privilege makes Windows-hosted cross builds
             // impossible without a machine-wide setting.
             log::warn!("symlink creation was denied by the OS; falling back to a copy");
+            // A relative source (force_symlink_relative passes one) resolves
+            // against the link's directory, not the process CWD — resolve it
+            // the same way is_directory does before copying.
+            let resolved_source = target
+                .parent()
+                .map(|parent| prefix_path(parent, source))
+                .unwrap_or_else(|| source.to_owned());
             let copy_result = if is_directory {
-                copy_dir_all(source, &target)
+                copy_dir_all(&resolved_source, &target)
             } else {
-                std::fs::copy(source, &target).map(|_| ())
+                std::fs::copy(&resolved_source, &target).map(|_| ())
             };
-            copy_result.map_err(|err| {
-                error(ErrorCause::IOError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    err,
-                )))
-            })
+            copy_result.map_err(|err| error(ErrorCause::IOError(err)))
         }
-        // The fallback copy arm above returns `Result<_, std::io::Error>`;
-        // this arm returns `Result<(), util::ln::Error>`.
-        r => r.map_err(|err: std::io::Error| {
-            error(ErrorCause::IOError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                err,
-            )))
-        }),
+        // Other symlink errors map as before.
+        r => r.map_err(|err| error(ErrorCause::IOError(err))),
     }?;
     Ok(())
 }

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -111,6 +111,19 @@ fn copy_dir_all_inner(
         return Ok(());
     }
     std::fs::create_dir_all(target)?;
+    let result = copy_dir_all_entries(source, target, visited);
+    // Pop on the way out: a directory that is merely *reachable twice* (two
+    // entries in the tree pointing at it) must still be copied at each
+    // location — only true ancestor cycles are meant to be cut here.
+    visited.remove(&canonical);
+    result
+}
+
+fn copy_dir_all_entries(
+    source: &Path,
+    target: &Path,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+) -> std::io::Result<()> {
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
         let dest = target.join(entry.file_name());

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -94,12 +94,31 @@ fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(target)?;
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
-        // metadata() (not file_type()) follows symlinks: a symlinked
-        // subdirectory inside the source tree must recurse as a directory,
-        // not fail in the copy branch below.
-        let entry_type = entry.metadata()?.file_type();
         let dest = target.join(entry.file_name());
-        if entry_type.is_dir() {
+        // metadata() follows symlinks: a symlinked subdirectory inside the
+        // source tree must recurse as a directory, not fail in the copy
+        // branch below. A broken link (dangling, or a self-referential loop)
+        // is skipped with a warning rather than failing the whole fallback —
+        // the symlink being replaced here was best-effort to begin with.
+        let entry_type = match entry.metadata() {
+            Ok(metadata) => metadata.file_type(),
+            Err(err) => {
+                log::warn!("skipping {:?} while copying: {err}", entry.path());
+                continue;
+            }
+        };
+        let is_dir = entry_type.is_dir()
+            || (entry
+                .path()
+                .symlink_metadata()
+                .map(|m| {
+                    m.file_type().is_symlink()
+                        && std::fs::metadata(entry.path())
+                            .map(|m| m.is_dir())
+                            .unwrap_or(false)
+                })
+                .unwrap_or(false));
+        if is_dir {
             copy_dir_all(&entry.path(), &dest)?;
         } else {
             std::fs::copy(entry.path(), &dest)?;

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -92,6 +92,24 @@ pub fn force_symlink(
 
 fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(target)?;
+    // Cycle guard: `metadata()` follows symlinks, so a self-referential or
+    // ancestor-pointing link would recurse forever and abort the whole
+    // fallback with a path-length error — the exact failure this fallback was
+    // added to avoid.
+    let mut visited = std::collections::HashSet::new();
+    copy_dir_all_inner(source, target, &mut visited)
+}
+
+fn copy_dir_all_inner(
+    source: &Path,
+    target: &Path,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+) -> std::io::Result<()> {
+    let canonical = source.canonicalize()?;
+    if !visited.insert(canonical.clone()) {
+        log::warn!("skipping already-copied directory {:?}", source);
+        return Ok(());
+    }
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
         let dest = target.join(entry.file_name());
@@ -107,19 +125,8 @@ fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
                 continue;
             }
         };
-        let is_dir = entry_type.is_dir()
-            || (entry
-                .path()
-                .symlink_metadata()
-                .map(|m| {
-                    m.file_type().is_symlink()
-                        && std::fs::metadata(entry.path())
-                            .map(|m| m.is_dir())
-                            .unwrap_or(false)
-                })
-                .unwrap_or(false));
-        if is_dir {
-            copy_dir_all(&entry.path(), &dest)?;
+        if entry_type.is_dir() {
+            copy_dir_all_inner(&entry.path(), &dest, visited)?;
         } else {
             std::fs::copy(entry.path(), &dest)?;
         }

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -56,12 +56,12 @@ pub fn force_symlink(
     } else if target.is_dir() {
         remove_dir_all(&target).map_err(|err| error(ErrorCause::IOError(err)))?;
     }
-    let _result = if is_directory {
+    let symlink_result = if is_directory {
         std::os::windows::fs::symlink_dir(source, &target)
     } else {
         std::os::windows::fs::symlink_file(source, &target)
     };
-    let result = match _result {
+    let result = match symlink_result {
         Err(err) if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD.0 as i32) => {
             // Creating symlinks on Windows requires Developer Mode or the
             // SeCreateSymbolicLinkPrivilege policy. Fall back to a copy: the
@@ -94,7 +94,10 @@ fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(target)?;
     for entry in std::fs::read_dir(source)? {
         let entry = entry?;
-        let entry_type = entry.file_type()?;
+        // metadata() (not file_type()) follows symlinks: a symlinked
+        // subdirectory inside the source tree must recurse as a directory,
+        // not fail in the copy branch below.
+        let entry_type = entry.metadata()?.file_type();
         let dest = target.join(entry.file_name());
         if entry_type.is_dir() {
             copy_dir_all(&entry.path(), &dest)?;

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -57,17 +57,55 @@ pub fn force_symlink(
         remove_dir_all(&target).map_err(|err| error(ErrorCause::IOError(err)))?;
     }
     let result = if is_directory {
-        std::os::windows::fs::symlink_dir(source, target)
+        std::os::windows::fs::symlink_dir(source, &target)
     } else {
-        std::os::windows::fs::symlink_file(source, target)
+        std::os::windows::fs::symlink_file(source, &target)
     };
-    result.map_err(|err| {
-        if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD.0 as i32) {
-            error(ErrorCause::SymlinkNotAllowed)
-        } else {
-            error(ErrorCause::IOError(err))
+    let result = match result {
+        Err(err) if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD.0 as i32) => {
+            // Creating symlinks on Windows requires Developer Mode or the
+            // SeCreateSymbolicLinkPrivilege policy. Fall back to a copy: the
+            // symlink here is a convenience for a build artifact (the copy is
+            // what Gradle packages either way), and failing the whole build
+            // over a missing privilege makes Windows-hosted cross builds
+            // impossible without a machine-wide setting.
+            log::warn!("symlink creation was denied by the OS; falling back to a copy");
+            let copy_result = if is_directory {
+                copy_dir_all(source, &target)
+            } else {
+                std::fs::copy(source, &target).map(|_| ())
+            };
+            copy_result.map_err(|err| {
+                error(ErrorCause::IOError(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    err,
+                )))
+            })
         }
-    })?;
+        // The fallback copy arm above returns `Result<_, std::io::Error>`;
+        // this arm returns `Result<(), util::ln::Error>`.
+        r => r.map_err(|err: std::io::Error| {
+            error(ErrorCause::IOError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                err,
+            )))
+        }),
+    }?;
+    Ok(())
+}
+
+fn copy_dir_all(source: &Path, target: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(target)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let entry_type = entry.file_type()?;
+        let dest = target.join(entry.file_name());
+        if entry_type.is_dir() {
+            copy_dir_all(&entry.path(), &dest)?;
+        } else {
+            std::fs::copy(entry.path(), &dest)?;
+        }
+    }
     Ok(())
 }
 

--- a/src/os/windows/ln.rs
+++ b/src/os/windows/ln.rs
@@ -61,7 +61,7 @@ pub fn force_symlink(
     } else {
         std::os::windows::fs::symlink_file(source, &target)
     };
-    let result = match symlink_result {
+    match symlink_result {
         Err(err) if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD.0 as i32) => {
             // Creating symlinks on Windows requires Developer Mode or the
             // SeCreateSymbolicLinkPrivilege policy. Fall back to a copy: the


### PR DESCRIPTION
## Summary

On Windows, creating the jniLibs symlink during `tauri android build`
(`force_symlink` → `symlink_file`) requires Developer Mode or the
`SeCreateSymbolicLinkPrivilege` policy. Without it, the whole Android build
aborts with:

```
Error failed to build Android app: Failed to create a symbolic link from
"...target\...\lib<app>lib.so" to "...jniLibs\x86_64\lib<app>lib.so"
(file clobbering enabled): Creation symbolic link is not allowed for this system.
```

This makes Android builds impossible for Windows users without a machine-wide
setting change, even though a plain copy of the artifact is semantically
identical for this use — the file is only consumed by the following Gradle
packaging step.

## Fix

When symlink creation fails with `ERROR_PRIVILEGE_NOT_HELD`, fall back to
`std::fs::copy` (files) / recursive `copy_dir_all` (directories) so the build
artifact is still materialized in `jniLibs`. A `log::warn!` notes the fallback
so users know why they are not getting a real symlink.

Two details handled in the fallback:

- a **relative source** (as passed by `force_symlink_relative` for the asset
  dir) is resolved against the link's parent via `prefix_path` before
  copying, so the copy reads from the right place instead of the process CWD;
- directory entries are classified via `entry.metadata()` (follows
  symlinks), so a symlinked subdirectory inside the source tree recurses as
  a directory; a broken link (dangling, or a self-referential loop) resolves
  with an error and is **skipped with a warning** rather than aborting the
  whole fallback — the symlink being replaced here was best-effort to begin
  with.

Native Windows builds without the privilege now succeed; hosts with
Developer Mode keep getting real symlinks exactly as before.

## Verification

On a Windows machine without Developer Mode:

- before: `tauri android build` fails at this step with the symlink error;
- after: the build proceeds — the artifact is materialized in `jniLibs`
  (copy) and Gradle packaging completes successfully.

End-to-end verified with a readest Android build on this fix: the jniLibs
artifact is packaged and the resulting APK installs and runs on an emulator.

## Notes

- `SymlinkNotAllowed` is no longer constructed in this path but remains part
  of the public error API for compatibility.
- If the maintainers prefer keeping real symlinks where possible and failing
  loudly otherwise, the `copy` fallback can be dropped and this reduced to a
  docs-only change (requiring Developer Mode) — but we believe the copy
  fallback matches the crate's own best-effort semantics here.